### PR TITLE
Updated case statement for Systemd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class splunkuf::params {
   case $::operatingsystem {
     'RedHat', 'CentOS': {
       case $::operatingsystemmajrelease {
-        7: {
+        '7': {
           $systemd = true
         }
         default: {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,7 @@ describe 'splunkuf' do
   context 'on RHEL7' do
     let :facts do
       {
-        :osfamily                   => 'RedHat',
+        :operatingsystem            => 'RedHat',
         :operatingsystemmajrelease  => '7',
         :architecure                => 'amd64',
       }
@@ -19,8 +19,7 @@ describe 'splunkuf' do
     end
 
     it do
-      should contain_file('/etc/init.d/splunkforwarder').with({
-      # should contain_file('/usr/lib/systemd/system/splunkforwarder.service').with({
+      should contain_file('/usr/lib/systemd/system/splunkforwarder.service').with({
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0755',


### PR DESCRIPTION
Updated the case statement to quote '7' since the
operatingsystemmajrelease fact is a string.
Fixed the spec tests to use operatingsystem => 'RedHat' since osfamily
is not a fact used in this module.
