### PR TITLE
Added ability to override the mgmtHostPort

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,8 +23,9 @@
 # Copyright 2015 Paul Badcock, unless otherwise noted.
 #
 class splunkuf (
-  $targeturi  = $::splunkuf::params::targeturi,
-  $systemd = $::splunkuf::params::systemd,
+  $targeturi    = $::splunkuf::params::targeturi,
+  $systemd      = $::splunkuf::params::systemd,
+  $mgmthostport = $::splunkuf::params::mgmthostport,
 ) inherits splunkuf::params {
 
   package {'splunkforwarder':
@@ -57,6 +58,17 @@ class splunkuf (
     content => template('splunkuf/deploymentclient.conf.erb'),
     notify  => Service['splunkforwarder'],
     require => Package['splunkforwarder'],
+  }
+
+  if $mgmthostport != undef {
+    file {'/opt/splunkforwarder/etc/system/local/web.conf':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('splunkuf/web.conf.erb'),
+      notify  => Service['splunkforwarder'],
+      require => Package['splunkforwarder'],
+    }
   }
 
   service {'splunkforwarder':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,8 @@
 class splunkuf::params {
   $targeturi = 'spunk.tld:8089'
 
+  $mgmthostport = undef
+
   case $::operatingsystem {
     'RedHat', 'CentOS': {
       case $::operatingsystemmajrelease {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -35,6 +35,66 @@ describe 'splunkuf' do
     end
 
     it do
+      should_not contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    end
+
+    it do
+      should contain_service('splunkforwarder').with({
+        'ensure'     => 'running',
+        'enable'     => 'true',
+      })
+    end
+  end
+
+  context 'on RHEL7 with Host Port Override' do
+    let :facts do
+      {
+        :operatingsystem            => 'RedHat',
+        :operatingsystemmajrelease  => '7',
+        :architecure                => 'amd64',
+      }
+    end
+
+    let :params do
+      {
+        :targeturi    => 'splunkwoo:8089',
+        :mgmthostport => '127.0.0.1::9089',
+      }
+    end
+
+    describe 'should install splunk forwarder package' do
+      it { should contain_package('splunkforwarder').with_ensure('latest') }
+    end
+
+    it do
+      should contain_file('/usr/lib/systemd/system/splunkforwarder.service').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0755',
+      })
+    end
+
+    it do
+      should contain_file('/opt/splunkforwarder/etc/system/local/deploymentclient.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    end
+
+    it do
+      should contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    end
+
+    it do
       should contain_service('splunkforwarder').with({
         'ensure'     => 'running',
         'enable'     => 'true',
@@ -75,6 +135,71 @@ describe 'splunkuf' do
         'group'   => 'root',
         'mode'    => '0644',
         })
+    end
+
+    it do
+      should_not contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    end
+
+    it do
+      should contain_service('splunkforwarder').with({
+        'ensure'     => 'running',
+        'enable'     => 'true',
+      })
+    end
+  end
+
+  context 'on RHEL6 with Host Port Override' do
+    let :facts do
+      {
+        :osfamily                   => 'RedHat',
+        :operatingsystemmajrelease  => '6',
+        :architecure                => 'amd64',
+      }
+    end
+
+    let :params do
+      {
+        :mgmthostport => '127.0.0.1:9089'
+      }
+    end
+
+    describe 'should install splunk forwarder package' do
+      let(:params) do
+        {
+          :targeturi => 'splunkwoo:8089',
+        }
+      end
+
+    it { should contain_package('splunkforwarder').with_ensure('latest') }
+    end
+
+    it do
+      should contain_file('/etc/init.d/splunkforwarder').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0755',
+      })
+    end
+
+    it do
+      should contain_file('/opt/splunkforwarder/etc/system/local/deploymentclient.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    end
+
+    it do
+      should contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
     end
 
     it do

--- a/templates/web.conf.erb
+++ b/templates/web.conf.erb
@@ -1,0 +1,5 @@
+# Managed through Puppet
+[settings]
+
+# location of splunkd; don't include http[s]:// in this anymore.
+mgmtHostPort = <%= @mgmthostport %>


### PR DESCRIPTION
There may be a need to override the port the management web service
starts up on, if another application is already listening on port
8089 (splunk default).

Added - mgmthostport param
Added - web.conf template
Added - logic to control management of web.conf
Updated - spec tests to accomdate changes
