### PR TITLE
Changed to osfamily to catch all RHEL derivitives

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,8 +21,8 @@ class splunkuf::params {
 
   $mgmthostport = undef
 
-  case $::operatingsystem {
-    'RedHat', 'CentOS': {
+  case $::osfamily {
+    'RedHat': {
       case $::operatingsystemmajrelease {
         '7': {
           $systemd = true


### PR DESCRIPTION
My issue was actually with OracleLinux, not RHEL, and when I looked at params.pp, I saw the bug.  If we specify osfamily instead of operatingsystem, we can classify based on the entire group of RedHat derivatives.  
