### PR TITLE
Add parametric system user support for services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,24 @@
-pkg/
-spec/fixtures/
-coverage/*
-Gemfile.lock
+# Idea
+.idea
+*.iml
+# Default .gitignore for Ruby
+*.gem
+*.rbc
+.bundle
+.config
+coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+# Vim
+*.swp
+# Puppet
+coverage/
+spec/fixtures/modules/*
+spec/fixtures/manifests/*
+

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ class { 'splunkuf':
 }
 ```
 
+Optional: To change the default system user (splunk) running the universal forwarder binary
+
+```Puppet
+class { 'splunkuf':
+  targeturi    => 'deployment.tld:8089',
+  system_user  => 'root',
+}
+```
 ## Reference
 
 Here, list the classes, types, providers, facts, etc contained in your module.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,10 @@
 #   String accepts a deployment server and port
 #   e.g. "deploymentserver.tld:8089"
 #
+# [*system_user*]
+#   System user that run splunk binary
+#   e.g. "splunk"
+#
 # === Examples
 #
 #  class { 'splunkuf':
@@ -25,45 +29,52 @@
 class splunkuf (
   $targeturi    = $::splunkuf::params::targeturi,
   $systemd      = $::splunkuf::params::systemd,
+  $system_user  = $::splunkuf::params::system_user,
   $mgmthostport = $::splunkuf::params::mgmthostport,
 ) inherits splunkuf::params {
 
-  package {'splunkforwarder':
+  package { 'splunkforwarder':
     ensure => latest,
   }
 
   case $systemd {
     true: {
-      file {'/usr/lib/systemd/system/splunkforwarder.service':
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0755',
-        source => 'puppet:///modules/splunkuf/splunkforwarder.service',
+      file { '/usr/lib/systemd/system/splunkforwarder.service':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template('splunkuf/splunkforwarder.service.erb'),
       }
     }
     default: {
-      file {'/etc/init.d/splunkforwarder':
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0755',
-        source => 'puppet:///modules/splunkuf/splunkforwarder',
+      file { '/etc/init.d/splunkforwarder':
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => template('splunkuf/splunkforwarder.erb'),
       }
     }
   }
 
-  file {'/opt/splunkforwarder/etc/system/local/deploymentclient.conf':
-    owner   => 'root',
-    group   => 'root',
+  file { '/opt/splunkforwarder':
+    ensure  => directory,
+    owner   => $system_user,
+    group   => $system_user,
+    recurse => true,
+    require => Package['splunkforwarder'],
+  } ->
+  file { '/opt/splunkforwarder/etc/system/local/deploymentclient.conf':
+    owner   => $system_user,
+    group   => $system_user,
     mode    => '0644',
     content => template('splunkuf/deploymentclient.conf.erb'),
     notify  => Service['splunkforwarder'],
-    require => Package['splunkforwarder'],
   }
 
   if $mgmthostport != undef {
-    file {'/opt/splunkforwarder/etc/system/local/web.conf':
-      owner   => 'root',
-      group   => 'root',
+    file { '/opt/splunkforwarder/etc/system/local/web.conf':
+      owner   => $system_user,
+      group   => $system_user,
       mode    => '0644',
       content => template('splunkuf/web.conf.erb'),
       notify  => Service['splunkforwarder'],
@@ -71,7 +82,7 @@ class splunkuf (
     }
   }
 
-  service {'splunkforwarder':
+  service { 'splunkforwarder':
     ensure => 'running',
     enable => true,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,10 @@
 #   String accepts a deployment server and port.
 #   e.g. "deploymentserver.tld:8089"
 #
+# [*system_user*]
+#   System user that run splunk binary
+#   e.g. "splunk"
+#
 # === Authors
 #
 # Paul Badcock <paul@bad.co.ck>
@@ -17,23 +21,26 @@
 # Copyright 2015 Paul Badcock, unless otherwise noted.
 #
 class splunkuf::params {
-  $targeturi = 'spunk.tld:8089'
+  $targeturi   = 'spunk.tld:8089'
+  $system_user = 'splunk'
 
   $mgmthostport = undef
 
   case $::osfamily {
     'RedHat': {
-      case $::operatingsystemmajrelease {
-        '7': {
-          $systemd = true
-        }
-        default: {
-          $systemd = false
-        }
+      if $::operatingsystemmajrelease >= 7 {
+        $systemd = true
       }
     }
-    /^(Debian|Ubuntu)$/: {
-      $systemd = false
+    'Debian': {
+      if $::operatingsystemmajrelease >= 8 {
+        $systemd = true
+      }
+    }
+    'Ubuntu': {
+      if $::operatingsystemmajrelease >= 15 {
+        $systemd = true
+      }
     }
     default: {
       $systemd = false

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "paulbadcock-splunkuf",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": "Paul Badcock",
   "summary": "Splunk Universal Forwarder Install",
   "license": "MIT",
@@ -15,7 +15,11 @@
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "12.04", "10.04" ]
+      "operatingsystemrelease": [ "16.10", "16.04", "15.10", "15.04", "14.04", "12.04", "10.04" ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [ "8.0", "7.0" ]
     }
   ],
   "dependencies": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -28,16 +28,16 @@ describe 'splunkuf' do
 
     it do
       should contain_file('/opt/splunkforwarder/etc/system/local/deploymentclient.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
         })
     end
 
     it do
       should_not contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
       })
     end
@@ -80,16 +80,16 @@ describe 'splunkuf' do
 
     it do
       should contain_file('/opt/splunkforwarder/etc/system/local/deploymentclient.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
       })
     end
 
     it do
       should contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
       })
     end
@@ -131,16 +131,16 @@ describe 'splunkuf' do
 
     it do
       should contain_file('/opt/splunkforwarder/etc/system/local/deploymentclient.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
         })
     end
 
     it do
       should_not contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
       })
     end
@@ -188,16 +188,16 @@ describe 'splunkuf' do
 
     it do
       should contain_file('/opt/splunkforwarder/etc/system/local/deploymentclient.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
       })
     end
 
     it do
       should contain_file('/opt/splunkforwarder/etc/system/local/web.conf').with({
-        'owner'   => 'root',
-        'group'   => 'root',
+        'owner'   => 'splunk',
+        'group'   => 'splunk',
         'mode'    => '0644',
       })
     end

--- a/templates/splunkforwarder.erb
+++ b/templates/splunkforwarder.erb
@@ -18,22 +18,38 @@ RETVAL=0
 
 splunk_start() {
   echo Starting Splunk...
+<% if @system_user == "root" %>
   "/opt/splunkforwarder/bin/splunk" start --accept-license --no-prompt --answer-yes
+<% else %>
+  su - <%= @system_user %> -c '/opt/splunkforwarder/bin/splunk start --accept-license --no-prompt --answer-yes'
+<% end %>
   RETVAL=$?
 }
 splunk_stop() {
   echo Stopping Splunk...
-  "/opt/splunkforwarder/bin/splunk" stop 
+<% if @system_user == "root" %>
+  "/opt/splunkforwarder/bin/splunk" stop
+<% else %>
+  su - <%= @system_user %> -c '/opt/splunkforwarder/bin/splunk stop'
+<% end %>
   RETVAL=$?
 }
 splunk_restart() {
   echo Restarting Splunk...
-  "/opt/splunkforwarder/bin/splunk" restart 
+<% if @system_user == "root" %>
+  "/opt/splunkforwarder/bin/splunk" restart
+<% else %>
+  su - <%= @system_user %> -c '/opt/splunkforwarder/bin/splunk restart'
+<% end %>
   RETVAL=$?
 }
 splunk_status() {
   echo Splunk status:
-  "/opt/splunkforwarder/bin/splunk" status 
+<% if @system_user == "root" %>
+  "/opt/splunkforwarder/bin/splunk" status
+<% else %>
+  su - <%= @system_user %> -c '/opt/splunkforwarder/bin/splunk status'
+<% end %>
   RETVAL=$?
 }
 case "$1" in

--- a/templates/splunkforwarder.service.erb
+++ b/templates/splunkforwarder.service.erb
@@ -2,14 +2,15 @@
 Description=Splunk Universal Forwarder
 Wants=network.target
 After=network.target
- 
+
 [Service]
 Type=forking
 RemainAfterExit=yes
+User=<%= @system_user %>
 ExecStart=/opt/splunkforwarder/bin/splunk start --answer-yes --no-prompt --accept-license
 ExecStop=/opt/splunkforwarder/bin/splunk stop
 ExecReload=/opt/splunkforwarder/bin/splunk restart
 StandardOutput=syslog
- 
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Splunkforwarder packages create usually a system user that run the universal forwarder binary as non privileged user rather than root. I added the support to pass it to the constructor of the module and fix permission for the splunk directory accordingly.

Defaults to 'splunk', Systemd service and SysV daemon are managed as ERB template to achieve this.